### PR TITLE
fix: Ensure horizontal scrolling for FASE category tabs

### DIFF
--- a/biologia_marina_pagina.html
+++ b/biologia_marina_pagina.html
@@ -142,21 +142,28 @@
 
         /* Pestañas de categorías */
         .category-tabs {
-            overflow-x: auto;
+            overflow-x: auto !important; /* Ensuring this is prioritized */
             background: rgba(200, 230, 201, 0.8); /* Green: Light mint green */
+            display: block; /* Or ensure it's a block-level element that can constrain its child */
+            width: 100%; /* Ensure it takes available width to constrain the child */
+            -webkit-overflow-scrolling: touch; /* For smoother scrolling on touch devices */
+            scrollbar-width: thin; /* Makes scrollbar thinner */
+            scrollbar-color: #888888 #e0e0e0; /* thumb color, track color */
         }
 
         .category-tabs-container {
-            display: flex;
+            display: flex !important; /* Ensuring this is prioritized */
             border-bottom: 1px solid #A5D6A7; /* Green: Light green border */
-            min-width: max-content;
+            min-width: max-content !important; /* Crucial for allowing overflow */
+            flex-wrap: nowrap !important; /* Prevent tabs from wrapping to new lines */
         }
 
         .category-tab {
             padding: 1rem 1.5rem;
             font-size: 0.9rem;
             font-weight: 600;
-            /* white-space: nowrap; */ /* Managed by container or default button behavior */
+            white-space: nowrap; /* Re-instate to prevent text inside tabs from wrapping */
+            flex-shrink: 0; /* Prevent tabs from shrinking */
             background: none;
             border: none;
             cursor: pointer;
@@ -455,10 +462,7 @@
         }
 
         /* Scrollbar Styling for Firefox */
-        .category-tabs {
-            scrollbar-width: thin; /* Makes scrollbar thinner */
-            scrollbar-color: #888888 #e0e0e0; /* thumb color, track color */
-        }
+        /* Firefox scrollbar properties moved into the main .category-tabs rule above */
     </style>
 </head>
 <body>

--- a/fisica_integrated.html
+++ b/fisica_integrated.html
@@ -142,21 +142,28 @@
 
         /* Pestañas de categorías */
         .category-tabs {
-            overflow-x: auto;
+            overflow-x: auto !important; /* Ensuring this is prioritized */
             background: rgba(248, 250, 252, 0.8);
+            display: block; /* Or ensure it's a block-level element that can constrain its child */
+            width: 100%; /* Ensure it takes available width to constrain the child */
+            -webkit-overflow-scrolling: touch; /* For smoother scrolling on touch devices */
+            scrollbar-width: thin; /* Makes scrollbar thinner */
+            scrollbar-color: #888888 #e0e0e0; /* thumb color, track color */
         }
 
         .category-tabs-container {
-            display: flex;
+            display: flex !important; /* Ensuring this is prioritized */
             border-bottom: 1px solid #e5e7eb;
-            min-width: max-content;
+            min-width: max-content !important; /* Crucial for allowing overflow */
+            flex-wrap: nowrap !important; /* Prevent tabs from wrapping to new lines */
         }
 
         .category-tab {
             padding: 1rem 1.5rem;
             font-size: 0.9rem;
             font-weight: 600;
-            /* white-space: nowrap; */ /* Managed by container or default button behavior */
+            white-space: nowrap; /* Re-instate to prevent text inside tabs from wrapping */
+            flex-shrink: 0; /* Prevent tabs from shrinking */
             background: none;
             border: none;
             cursor: pointer;
@@ -455,10 +462,7 @@
         }
 
         /* Scrollbar Styling for Firefox */
-        .category-tabs {
-            scrollbar-width: thin; /* Makes scrollbar thinner */
-            scrollbar-color: #888888 #e0e0e0; /* thumb color, track color */
-        }
+        /* Firefox scrollbar properties moved into the main .category-tabs rule above */
     </style>
 </head>
 <body>

--- a/geologia.html
+++ b/geologia.html
@@ -142,21 +142,28 @@
 
         /* Pestañas de categorías */
         .category-tabs {
-            overflow-x: auto;
+            overflow-x: auto !important; /* Ensuring this is prioritized */
             background: rgba(239, 235, 220, 0.8); /* Earthy: Lighter beige */
+            display: block; /* Or ensure it's a block-level element that can constrain its child */
+            width: 100%; /* Ensure it takes available width to constrain the child */
+            -webkit-overflow-scrolling: touch; /* For smoother scrolling on touch devices */
+            scrollbar-width: thin; /* Makes scrollbar thinner */
+            scrollbar-color: #888888 #e0e0e0; /* thumb color, track color */
         }
 
         .category-tabs-container {
-            display: flex;
+            display: flex !important; /* Ensuring this is prioritized */
             border-bottom: 1px solid #d7ccc8; /* Earthy: Light brown border */
-            min-width: max-content;
+            min-width: max-content !important; /* Crucial for allowing overflow */
+            flex-wrap: nowrap !important; /* Prevent tabs from wrapping to new lines */
         }
 
         .category-tab {
             padding: 1rem 1.5rem;
             font-size: 0.9rem;
             font-weight: 600;
-            /* white-space: nowrap; */ /* Managed by container or default button behavior */
+            white-space: nowrap; /* Re-instate to prevent text inside tabs from wrapping */
+            flex-shrink: 0; /* Prevent tabs from shrinking */
             background: none;
             border: none;
             cursor: pointer;
@@ -455,10 +462,7 @@
         }
 
         /* Scrollbar Styling for Firefox */
-        .category-tabs {
-            scrollbar-width: thin; /* Makes scrollbar thinner */
-            scrollbar-color: #888888 #e0e0e0; /* thumb color, track color */
-        }
+        /* Firefox scrollbar properties moved into the main .category-tabs rule above */
     </style>
 </head>
 <body>

--- a/quimica_marina.html
+++ b/quimica_marina.html
@@ -147,21 +147,28 @@
 
         /* Pestañas de categorías */
         .category-tabs {
-            overflow-x: auto;
+            overflow-x: auto !important; /* Ensuring this is prioritized */
             background: rgba(200, 230, 250, 0.8); /* Celeste: Light blue tint */
+            display: block; /* Or ensure it's a block-level element that can constrain its child */
+            width: 100%; /* Ensure it takes available width to constrain the child */
+            -webkit-overflow-scrolling: touch; /* For smoother scrolling on touch devices */
+            scrollbar-width: thin; /* Makes scrollbar thinner */
+            scrollbar-color: #888888 #e0e0e0; /* thumb color, track color */
         }
 
         .category-tabs-container {
-            display: flex;
+            display: flex !important; /* Ensuring this is prioritized */
             border-bottom: 1px solid #A8D8EA; /* Celeste: Light blue border */
-            min-width: max-content;
+            min-width: max-content !important; /* Crucial for allowing overflow */
+            flex-wrap: nowrap !important; /* Prevent tabs from wrapping to new lines */
         }
 
         .category-tab {
             padding: 1rem 1.1rem; /* Reduced horizontal padding */
             font-size: 0.9rem;
             font-weight: 600;
-            /* white-space: nowrap; /* Removed as container handles overflow */
+            white-space: nowrap; /* Re-instate to prevent text inside tabs from wrapping */
+            flex-shrink: 0; /* Prevent tabs from shrinking */
             background: none;
             border: none;
             cursor: pointer;
@@ -484,10 +491,7 @@
         }
 
         /* Scrollbar Styling for Firefox */
-        .category-tabs {
-            scrollbar-width: thin; /* Makes scrollbar thinner */
-            scrollbar-color: #888888 #e0e0e0; /* thumb color, track color */
-        }
+        /* Firefox scrollbar properties moved into the main .category-tabs rule above */
     </style>
 </head>
 <body>


### PR DESCRIPTION
- Corrected and enhanced CSS for .category-tabs, .category-tabs-container, and .category-tab across all four module pages (fisica, geologia, biologia, quimica).
- Ensured 'overflow-x: auto' is effective for horizontal scrolling.
- Added 'min-width: max-content' and 'flex-wrap: nowrap' to tab container.
- Added 'white-space: nowrap' and 'flex-shrink: 0' to individual tabs.
- This fixes a bug where the horizontal scrollbar was not appearing when FASE tabs overflowed the available width, making all FASEs accessible.